### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@6
+  hmpps: ministryofjustice/hmpps@7
   mem: circleci/rememborb@0.0.2
-  
+
 jobs:
   create_app_version:
     docker:
@@ -12,7 +12,7 @@ jobs:
       - mem/remember:
           env_var: APP_VERSION
           value: "latest"
-    
+
 workflows:
   version: 2
   build-test-and-deploy:

--- a/helm_deploy/create-and-vary-a-licence-wiremock/Chart.yaml
+++ b/helm_deploy/create-and-vary-a-licence-wiremock/Chart.yaml
@@ -5,5 +5,5 @@ name: create-and-vary-a-licence-wiremock
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: 2.1.0
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/helm_deploy/create-and-vary-a-licence-wiremock/values.yaml
+++ b/helm_deploy/create-and-vary-a-licence-wiremock/values.yaml
@@ -1,4 +1,3 @@
----
 generic-service:
   nameOverride: hmpps-community-api-wiremock
   replicaCount: 2
@@ -11,8 +10,8 @@ generic-service:
 
   ingress:
     enabled: true
-    hosts: 
-     - app-hostname.local    # override per environment
+    hosts:
+      - app-hostname.local # override per environment
     tlsSecretName: create-and-vary-a-licence-wiremock-cert
     v1_2_enabled: true
     v0_47_enabled: false
@@ -50,14 +49,8 @@ generic-service:
       SYSTEM_CLIENT_SECRET: "SYSTEM_CLIENT_SECRET"
 
   allowlist:
-    office: "217.33.148.210/32"
-    petty_france_wifi: "213.121.161.112/28"
-    mojvpn: "81.134.202.29/32"
-    global-protect: "35.176.93.186/32"
-    health-kick: "35.177.252.195/32"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
+    groups:
+      - internal
 
   podSecurityContext:
     fsGroup: 1001
@@ -65,5 +58,3 @@ generic-service:
   securityContext:
     runAsUser: 1001
     runAsNonRoot: true
-
-


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

1 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/create-and-vary-a-licence-wiremock/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal`
- The size of the allowlist defined in this file will change: `8 => 0 (8 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick
  
